### PR TITLE
BugFix - GameFinder screen no tag

### DIFF
--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/adapter/persistence/GameRepository.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/adapter/persistence/GameRepository.kt
@@ -70,12 +70,23 @@ class GameRepository(database: GameFinderDatabase) : GamePersistencePort {
             .map { games -> games.map { it.toModel() } }
     }
 
-    override fun findGames(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>> {
+    override fun findGamesByFriendsAndTags(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>> {
         return dbQueries
-            .findMultiplayerGames(
+            .findMultiplayerGamesByFriendsAndTags(
                 friendCount = friendIds.size,
                 friendIds.map { it.toLong() },
                 tagIds.map { it.toLong() }
+            )
+            .asFlow()
+            .mapToList(Dispatchers.IO)
+            .map { games -> games.map { it.toModel() } }
+    }
+
+    override fun findGamesByFriends(friendIds: List<Int>): Flow<List<Game>> {
+        return dbQueries
+            .findMultiplayerGamesByFriends(
+                friendCount = friendIds.size,
+                friendIds.map { it.toLong() }
             )
             .asFlow()
             .mapToList(Dispatchers.IO)

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/GameService.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/GameService.kt
@@ -29,8 +29,12 @@ class GameService(private val persistencePort: GamePersistencePort) : GameUseCas
         return persistencePort.getGamesByQuery(query)
     }
 
-    override fun findGames(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>> {
-        return persistencePort.findGames(friendIds, tagIds)
+    override fun findGames(friendIds: List<Int>, tagIds: List<Int>?): Flow<List<Game>> {
+        return if (tagIds.isNullOrEmpty()) {
+            persistencePort.findGamesByFriends(friendIds)
+        } else {
+            persistencePort.findGamesByFriendsAndTags(friendIds, tagIds)
+        }
     }
 
     override suspend fun updateMultiplayerMode(gameId: Int, multiplayerMode: MultiplayerMode) {

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/port/in/GameUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/port/in/GameUseCase.kt
@@ -18,7 +18,7 @@ interface GameUseCase {
 
     fun getGamesByQuery(query: GameQuery): Flow<List<Game>>
 
-    fun findGames(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>>
+    fun findGames(friendIds: List<Int>, tagIds: List<Int>?): Flow<List<Game>>
 
     suspend fun updateMultiplayerMode(gameId: Int, multiplayerMode: MultiplayerMode)
 

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/port/out/GamePersistencePort.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/core/application/port/out/GamePersistencePort.kt
@@ -18,7 +18,9 @@ interface GamePersistencePort {
 
     fun getGamesByQuery(query: GameQuery): Flow<List<Game>>
 
-    fun findGames(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>>
+    fun findGamesByFriendsAndTags(friendIds: List<Int>, tagIds: List<Int>): Flow<List<Game>>
+
+    fun findGamesByFriends(friendIds: List<Int>): Flow<List<Game>>
 
     suspend fun updateMultiplayerMode(gameId: Int, multiplayerMode: MultiplayerMode)
 

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/game_finder/GameFinderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/game_finder/GameFinderScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Done
+import androidx.compose.material.icons.filled.FilterListOff
 import androidx.compose.material.icons.filled.Group
 import androidx.compose.material.icons.filled.Label
 import androidx.compose.material3.*
@@ -15,10 +16,13 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.getScreenModel
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
 import de.hive.gamefinder.components.FormIconHeader
 import de.hive.gamefinder.core.utils.UiEvents
 import io.kamel.image.KamelImage
@@ -35,12 +39,16 @@ class GameFinderScreen : Screen {
     @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
     @Composable
     override fun Content() {
+        val navigator = LocalNavigator.currentOrThrow
+
         val screenModel = getScreenModel<GameFinderScreenModel>()
         val state = screenModel.state.collectAsState()
 
         val snackbarHostState = remember { SnackbarHostState() }
         val selectedFriends = remember { mutableStateListOf<Int>() }
         val deselectedTags = remember { mutableStateListOf<Int>() }
+
+        var showNoFilterOptionsAlertDialog by remember { mutableStateOf(false) }
 
         fun selectFriend(friendId: Int) {
             if (friendId in selectedFriends) selectedFriends.remove(friendId) else selectedFriends.add(friendId)
@@ -86,69 +94,75 @@ class GameFinderScreen : Screen {
                         val tags = selectionState.tags
                         val games = selectionState.games
 
+                        showNoFilterOptionsAlertDialog = friends.isEmpty()
+
                         Column(
                             modifier = Modifier.padding(16.dp),
                             verticalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
-                            FormIconHeader(
-                                Icons.Filled.Group,
-                                contentDescription = "Friend Selection Header Icon",
-                                headerText = "Friends"
-                            )
+                            if (friends.isNotEmpty()) {
+                                FormIconHeader(
+                                    Icons.Filled.Group,
+                                    contentDescription = "Friend Selection Header Icon",
+                                    headerText = "Friends"
+                                )
 
-                            Column {
-                                friends.forEach { friend ->
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(56.dp)
-                                            .toggleable(
-                                                value = (friend.id in selectedFriends),
-                                                onValueChange = { selectFriend(friend.id) },
-                                                role = Role.Checkbox
+                                Column {
+                                    friends.forEach { friend ->
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(56.dp)
+                                                .toggleable(
+                                                    value = (friend.id in selectedFriends),
+                                                    onValueChange = { selectFriend(friend.id) },
+                                                    role = Role.Checkbox
+                                                )
+                                                .padding(horizontal = 16.dp),
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Checkbox(
+                                                checked = (friend.id in selectedFriends),
+                                                onCheckedChange = null
                                             )
-                                            .padding(horizontal = 16.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Checkbox(
-                                            checked = (friend.id in selectedFriends),
-                                            onCheckedChange = null
-                                        )
-                                        Text(
-                                            text = friend.name,
-                                            style = MaterialTheme.typography.bodyLarge,
-                                            modifier = Modifier.padding(start = 16.dp)
-                                        )
+                                            Text(
+                                                text = friend.name,
+                                                style = MaterialTheme.typography.bodyLarge,
+                                                modifier = Modifier.padding(start = 16.dp)
+                                            )
+                                        }
                                     }
                                 }
                             }
 
-                            FormIconHeader(
-                                Icons.Filled.Label,
-                                contentDescription = "Tag Selection Header Icon",
-                                headerText = "Tags"
-                            )
+                            if (tags.isNotEmpty()) {
+                                FormIconHeader(
+                                    Icons.Filled.Label,
+                                    contentDescription = "Tag Selection Header Icon",
+                                    headerText = "Tags"
+                                )
 
-                            FlowRow (
-                                modifier = Modifier.wrapContentHeight(align = Alignment.Top),
-                                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
-                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                            ) {
-                                tags.forEach {
-                                    FilterChip(
-                                        selected = (it.id !in deselectedTags),
-                                        onClick = { selectTag(it.id) },
-                                        label = { Text(it.tag) },
-                                        leadingIcon = {
-                                            if (it.id !in deselectedTags) {
-                                                Icon(
-                                                    Icons.Filled.Done,
-                                                    contentDescription = null,
-                                                    modifier = Modifier.size(FilterChipDefaults.IconSize)
-                                                )
+                                FlowRow (
+                                    modifier = Modifier.wrapContentHeight(align = Alignment.Top),
+                                    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    tags.forEach {
+                                        FilterChip(
+                                            selected = (it.id !in deselectedTags),
+                                            onClick = { selectTag(it.id) },
+                                            label = { Text(it.tag) },
+                                            leadingIcon = {
+                                                if (it.id !in deselectedTags) {
+                                                    Icon(
+                                                        Icons.Filled.Done,
+                                                        contentDescription = null,
+                                                        modifier = Modifier.size(FilterChipDefaults.IconSize)
+                                                    )
+                                                }
                                             }
-                                        }
-                                    )
+                                        )
+                                    }
                                 }
                             }
                         }
@@ -162,17 +176,70 @@ class GameFinderScreen : Screen {
 
                         LazyRow(
                             contentPadding = PaddingValues(16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             items(games) {
-                                KamelImage(
-                                    resource = asyncPainterResource("$IGDB_IMAGE_ENDPOINT${it.coverImageId}.jpg"),
-                                    contentDescription = "${it.name} - Cover",
-                                    modifier = Modifier.clip(RoundedCornerShape(16.dp)),
-                                    //contentScale = ContentScale.Crop,
-                                    onLoading = { progress -> CircularProgressIndicator(progress) }
-                                )
+                                Box(
+                                    modifier = Modifier
+                                        .width(300.dp)
+                                        .wrapContentHeight()
+                                        .clip(RoundedCornerShape(16.dp))
+                                ) {
+                                    KamelImage(
+                                        resource = asyncPainterResource("$IGDB_IMAGE_ENDPOINT${it.coverImageId}.jpg"),
+                                        contentDescription = "${it.name} - Cover",
+                                        contentScale = ContentScale.FillWidth,
+                                        onLoading = { progress -> CircularProgressIndicator(progress) }
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (showNoFilterOptionsAlertDialog) {
+                // TODO : Replace this with BasicAlertDialog if compose multiplatform 1.6 arrives
+                AlertDialog(
+                    onDismissRequest = {
+                        // Dismiss the dialog when the user clicks outside the dialog or on the back
+                        // button. If you want to disable that functionality, simply use an empty
+                        // onDismissRequest.
+                        showNoFilterOptionsAlertDialog = false
+                    }
+                ) {
+                    Surface(
+                        modifier = Modifier
+                            .width(350.dp)
+                            .wrapContentHeight(),
+                        shape = MaterialTheme.shapes.large,
+                        tonalElevation = AlertDialogDefaults.TonalElevation
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(Icons.Filled.FilterListOff, contentDescription = "Alert dialog header icon")
+
+                            Text(
+                                text = "No filter Options",
+                                style = MaterialTheme.typography.headlineMedium
+                            )
+
+                            Text(
+                                text = "Since you haven't added any friends yet, I can't help you find the right games.",
+                            )
+
+                            TextButton(
+                                onClick = {
+                                    showNoFilterOptionsAlertDialog = false
+                                    navigator.pop()
+                                },
+                                modifier = Modifier.align(Alignment.End)
+                            ) {
+                                Text("Confirm")
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/game_finder/GameFinderScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/game_finder/GameFinderScreenModel.kt
@@ -48,12 +48,12 @@ class GameFinderScreenModel(
         screenModelScope.launch {
             // Subtract the deselected Tags from the tag-list
             tagUseCase.getTags().collect { tags ->
-                val selectedTags = tags.mapNotNull { tag -> tag.id.takeUnless { it in deselectedTags } }
+                val selectedTags = if (tags.isNotEmpty()) {
+                    tags.mapNotNull { tag -> tag.id.takeUnless { it in deselectedTags } }
+                } else null
 
                 if (selectedFriends.isEmpty()) {
                     _eventsFlow.trySend(UiEvents.ShowSnackbar("You must select at least one of your friends!"))
-                } else if (selectedTags.isEmpty()) {
-                    _eventsFlow.trySend(UiEvents.ShowSnackbar("You must select at least one tag!"))
                 } else {
                     gameUseCase.findGames(selectedFriends, selectedTags).collect {
                         mutableState.update { currentState ->

--- a/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/navigation/NavigationScreen.kt
+++ b/composeApp/src/commonMain/kotlin/de/hive/gamefinder/feature/navigation/NavigationScreen.kt
@@ -31,12 +31,14 @@ fun NavigationWrapper(
     var selectedRoute by remember { mutableStateOf(NavigationRoutes.LIBRARY) }
     var openDialog by remember { mutableStateOf(false) }
 
+    // TODO : Update the selected route when we go back!
+
     if (navigationType == NavigationType.PERMANENT_NAVIGATION_DRAWER) {
         PermanentNavigationDrawer(
             drawerContent = {
                 PermanentNavigationDrawerContent(
                     selectedRoute = selectedRoute,
-                    onDrawerItemClicked = { selectedRoute = it.name; navigator.replaceAll(it.destination) }
+                    onDrawerItemClicked = { selectedRoute = it.name; navigator.push(it.destination) }
                 )
             },
         ) {
@@ -50,7 +52,7 @@ fun NavigationWrapper(
                     onDrawerClicked = {
                         scope.launch { drawerState.close() }
                     },
-                    onDrawerItemClicked = { selectedRoute = it.name; navigator.replaceAll(it.destination) },
+                    onDrawerItemClicked = { selectedRoute = it.name; navigator.push(it.destination) },
                     onActionButtonClicked = { openDialog = true }
                 )
             },
@@ -60,7 +62,7 @@ fun NavigationWrapper(
                 navigationType = navigationType,
                 selectedRoute = selectedRoute,
                 onActionButtonClicked = { openDialog = true },
-                onDrawerItemClicked = { selectedRoute = it.name; navigator.replaceAll(it.destination) }
+                onDrawerItemClicked = { selectedRoute = it.name; navigator.push(it.destination) }
             ) {
                 scope.launch { drawerState.open() }
             }

--- a/composeApp/src/commonMain/resources/MR/base/strings.xml
+++ b/composeApp/src/commonMain/resources/MR/base/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+    <string name="libary_screen_headline">Library</string>
+</resources>

--- a/composeApp/src/commonMain/sqldelight/database/GameFinder.sq
+++ b/composeApp/src/commonMain/sqldelight/database/GameFinder.sq
@@ -67,7 +67,7 @@ WHERE (:launcher IS NULL OR launcher = :launcher)
 AND (:onlineCoop IS NULL OR online_coop = :onlineCoop)
 AND (:campaignCoop IS NULL OR campaign_coop = :campaignCoop);
 
-findMultiplayerGames:
+findMultiplayerGamesByFriendsAndTags:
 SELECT DISTINCT ge.* FROM game_entity AS ge
 LEFT OUTER JOIN main.game_friends gf ON ge.id = gf.game_id
 LEFT OUTER JOIN main.game_tags gt ON ge.id = gt.game_id
@@ -75,6 +75,14 @@ WHERE ge.online_coop = 1
 AND ge.online_max_players >= (:friendCount)
 AND gf.friend_id IN ?
 AND gt.tag_id IN ?;
+
+findMultiplayerGamesByFriends:
+SELECT DISTINCT ge.* FROM game_entity AS ge
+LEFT OUTER JOIN main.game_friends gf ON ge.id = gf.game_id
+LEFT OUTER JOIN main.game_tags gt ON ge.id = gt.game_id
+WHERE ge.online_coop = 1
+AND ge.online_max_players >= (:friendCount)
+AND gf.friend_id IN ?;
 
 addGame:
 INSERT OR REPLACE INTO game_entity

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,6 @@ buildKonfig = "0.15.1"
 sqlDelight = "2.0.1"
 multiplatformSettings = "1.1.1"
 moko-resources = "0.23.0"
-accompanist = "0.34.0"
 
 logback = "1.4.14"
 napier = "2.7.1"
@@ -73,8 +72,8 @@ koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin-cor
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koin-compose"}
 multiplatform-noArg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatformSettings" }
 multiplatform-Coroutines = { module = "com.russhwolf:multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
-# moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
-# moko-resourcesCompose = { module = "dev.icerock.moko:resources-compose", version.ref = "moko-resources"}
+moko-resources = { module = "dev.icerock.moko:resources", version.ref = "moko-resources" }
+moko-resourcesCompose = { module = "dev.icerock.moko:resources-compose", version.ref = "moko-resources"}
 
 sqlDelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqlDelight" }
 sqlDelight-android = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
@@ -102,4 +101,4 @@ serialization = { id = "org.jetbrains.kotlin.plugin.serialization" , version.ref
 sqlDelight-plugin = { id = "app.cash.sqldelight", version.ref = "sqlDelight" }
 
 buildKonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildKonfig" }
-# multiplatform-resources = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko-resources" }
+multiplatform-resources = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko-resources" }


### PR DESCRIPTION
Closes #19 

Fixes a Bug in the GameFinder Screen, that prevent the user to search for a game when no tag is created.

As solution the GameService calls a different database query when the tag list is null. This query only searches for the selected friends.